### PR TITLE
classlibrary: remove dependency on JoshMisc quark

### DIFF
--- a/Classes/ClassExtensions/extString_VT.sc
+++ b/Classes/ClassExtensions/extString_VT.sc
@@ -53,4 +53,8 @@
 		);
 	}
 
+	capitalize {
+		^this[0].toUpper++this[1..]
+	}
+
 }


### PR DESCRIPTION
just stole this String ext method from JoshMisc quark