### PR TITLE
set some type and default value for VTMValue

### DIFF
--- a/Classes/Value/VTMValue.sc
+++ b/Classes/Value/VTMValue.sc
@@ -6,7 +6,7 @@ VTMValue {
 	var properties;
 
 	*prDefaultValueForType{
-		this.subclassResponsibility(thisMethod);
+		^nil;
 	}
 
 	*typeToClass{arg val;
@@ -18,7 +18,7 @@ VTMValue {
 	}
 
 	*type{
-		this.subclassResponsibility(thisMethod);
+		\none;
 	}
 
 	type{


### PR DESCRIPTION
fixes for when no type given
```
~myAttr = VTMAttribute('heisann', (path: '/myPath'));
~myAttr.value
```